### PR TITLE
Add reading time and word count

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -77,6 +77,7 @@ back_to_top = true # show back-to-top button
 toc = true # show table-of-contents
 comment = false # enable comment
 copy = true # show copy button in code block
+stats = true # show reading time and word count
 
 outdate_alert = false
 outdate_alert_days = 12
@@ -214,6 +215,7 @@ lang = "en"
 toc = true
 comment = false
 copy = true
+stats = true
 outdate_alert = true
 outdate_alert_days = 120
 math = false
@@ -242,6 +244,10 @@ Set `mermaid = true` to enable chart rendering with Mermaid.
 ## Featured Mark
 
 Set `featured = true` to display an asterisk(*) mark in front of the title.
+
+## Stats
+
+Set `stats = true` to show reading time and word count of a post.
 
 ## Outdate Alert
 

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1364,6 +1364,16 @@ body.post {
       }
     }
 
+    #stats {
+      color: var(--text-pale-color);
+      margin-bottom: 1em;
+
+      #reading-time,
+      #word-count {
+        margin-right: 1em;
+      }
+    }
+
     #tags {
       margin-bottom: 1em;
       display: flex;

--- a/templates/post.html
+++ b/templates/post.html
@@ -99,10 +99,13 @@
             {% endif -%}
           </div>
 
+          {% if page.extra.stats is defined %}{% set show_stats = page.extra.stats %}{% else %}{% set show_stats = section.extra.stats %}{% endif %}
+          {% if show_stats %}
           <div id="stats">
             <span id="reading-time">{{ page.reading_time }} min read</span>
             <span id="word-count">{{ page.word_count }} words</span>
           </div>
+          {% endif %}
 
           {% if page.taxonomies.tags is defined %}
           <div id="tags">

--- a/templates/post.html
+++ b/templates/post.html
@@ -99,6 +99,11 @@
             {% endif -%}
           </div>
 
+          <div id="stats">
+            <span id="reading-time">{{ page.reading_time }} min read</span>
+            <span id="word-count">{{ page.word_count }} words</span>
+          </div>
+
           {% if page.taxonomies.tags is defined %}
           <div id="tags">
             {% for tag in page.taxonomies.tags -%}


### PR DESCRIPTION
## Summary
- show reading time and word count on post pages
- style new stats in post info

## Testing
- `zola build` *(fails: `zola` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840da283398832fb4a5f46bd88a48d0