### PR TITLE
Add configurable OpenGraph metadata support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -311,6 +311,37 @@ After you setup your endpoint, set `reaction_endpoint = "<your-endpoint>"` and `
 
 Giscus also support a reaction feature, but it requires visitors to log in to GitHub, you can disable it in giscus's settings.
 
+## OpenGraph
+
+Serene can render OpenGraph meta tags for richer previews when your pages are shared.
+
+Enable it in `config.toml`:
+
+```toml
+[extra.opengraph]
+enable = true
+site_name = "My Blog"
+default_type = "website"
+# default_image = "img/og-image.png"
+default_image_alt = "My Blog logo"
+# locale = "en_US"
+```
+
+All fields are optional except `enable`. `site_name` defaults to `title`, `default_type` defaults to `website`, and `default_image` can point to an image inside the `static` directory or an absolute URL.
+
+You can override OpenGraph values per page or per section in front matter:
+
+```toml
+[extra.opengraph]
+title = "Custom Page Title"
+description = "A different description just for social previews."
+type = "article"
+image = "img/posts/custom-og.png"
+image_alt = "Custom cover"
+```
+
+For posts, the theme automatically falls back to the summary, description, or section description when an explicit OpenGraph description is not provided.
+
 ## Codeblock
 
 Zola supports some [annotations for code blocks](https://www.getzola.org/documentation/content/syntax-highlighting/#annotations).

--- a/config.example.toml
+++ b/config.example.toml
@@ -60,3 +60,13 @@ not_found_recover_text = "« back to home »"
 reaction = false # Whether to enable anonymous emoji reactions (Note: You need to set up a working api endpoint to enable this feature)
 reaction_align = "right" # "left" | "center" | "right"
 reaction_endpoint = "https://example.com/api/reaction"
+
+[extra.opengraph]
+enable = false # Whether to render OpenGraph meta tags
+site_name = "xxxx" # Optional override for og:site_name, defaults to "title"
+default_type = "website" # Default og:type when not overridden by content
+# title = "xxxx" # Optional site-wide override for og:title
+# description = "xxxx xxxx xxxx" # Optional site-wide override for og:description
+# default_image = "img/og-image.png" # Optional default OpenGraph image path (relative to the static directory)
+default_image_alt = "xxxx" # Alternative text used for the default OpenGraph image
+# locale = "en_US" # Optional locale identifier for og:locale

--- a/templates/_head_extend.html
+++ b/templates/_head_extend.html
@@ -1,0 +1,1 @@
+{% include "_opengraph.html" %}

--- a/templates/_opengraph.html
+++ b/templates/_opengraph.html
@@ -1,0 +1,136 @@
+{% if config.extra.opengraph is defined %}
+  {% set opengraph_cfg = config.extra.opengraph %}
+  {% if opengraph_cfg.enable | default(value=false) %}
+    {% set site_name = opengraph_cfg.site_name | default(value=config.title) %}
+    {% set og_title = opengraph_cfg.title | default(value=config.title) %}
+    {% set og_description = opengraph_cfg.description | default(value=config.description) %}
+    {% set og_type = opengraph_cfg.default_type | default(value="website") %}
+    {% set og_locale = opengraph_cfg.locale | default(value="") %}
+    {% set image_path = opengraph_cfg.default_image | default(value="") %}
+    {% set image_alt = opengraph_cfg.default_image_alt | default(value=site_name) %}
+
+    {% if page is defined %}
+      {% set page_og = {} %}
+      {% if page.extra.opengraph is defined %}
+        {% set page_og = page.extra.opengraph %}
+      {% endif %}
+
+      {% if page_og.title is defined %}
+        {% set og_title = page_og.title %}
+      {% else %}
+        {% set og_title = page.title %}
+      {% endif %}
+
+      {% if page_og.description is defined %}
+        {% set og_description = page_og.description %}
+      {% else %}
+        {% if page.summary %}
+          {% set og_description = page.summary %}
+        {% elif page.description %}
+          {% set og_description = page.description %}
+        {% elif page.extra is defined and page.extra.summary is defined %}
+          {% set og_description = page.extra.summary %}
+        {% elif section is defined and section.description %}
+          {% set og_description = section.description %}
+        {% endif %}
+      {% endif %}
+
+      {% if page_og.type is defined %}
+        {% set og_type = page_og.type %}
+      {% else %}
+        {% set og_type = "article" %}
+      {% endif %}
+
+      {% if page_og.image is defined %}
+        {% set image_path = page_og.image %}
+      {% elif page.extra is defined and page.extra.image is defined %}
+        {% set image_path = page.extra.image %}
+      {% endif %}
+
+      {% if page_og.image_alt is defined %}
+        {% set image_alt = page_og.image_alt %}
+      {% elif page.extra is defined and page.extra.image_alt is defined %}
+        {% set image_alt = page.extra.image_alt %}
+      {% endif %}
+    {% elif section is defined %}
+      {% set section_og = {} %}
+      {% if section.extra.opengraph is defined %}
+        {% set section_og = section.extra.opengraph %}
+      {% endif %}
+
+      {% if section_og.title is defined %}
+        {% set og_title = section_og.title %}
+      {% elif section.title %}
+        {% set og_title = section.title %}
+      {% endif %}
+
+      {% if section_og.description is defined %}
+        {% set og_description = section_og.description %}
+      {% elif section.description %}
+        {% set og_description = section.description %}
+      {% endif %}
+
+      {% if section_og.type is defined %}
+        {% set og_type = section_og.type %}
+      {% endif %}
+
+      {% if section_og.image is defined %}
+        {% set image_path = section_og.image %}
+      {% elif section.extra is defined and section.extra.image is defined %}
+        {% set image_path = section.extra.image %}
+      {% endif %}
+
+      {% if section_og.image_alt is defined %}
+        {% set image_alt = section_og.image_alt %}
+      {% elif section.extra is defined and section.extra.image_alt is defined %}
+        {% set image_alt = section.extra.image_alt %}
+      {% endif %}
+    {% elif term is defined %}
+      {% set og_title = term.name %}
+      {% set og_description = term.name %}
+    {% elif taxonomy is defined %}
+      {% set og_title = taxonomy.name | capitalize %}
+      {% set og_description = taxonomy.name | capitalize %}
+    {% endif %}
+
+    {% set og_url = config.base_url %}
+    {% if current_url is defined %}
+      {% set og_url = current_url %}
+    {% endif %}
+
+    {% set og_image = "" %}
+    {% if image_path %}
+      {% if image_path is matching("^https?://") %}
+        {% set og_image = image_path %}
+      {% else %}
+        {% set image_clean_path = image_path | trim_start_matches(pat="/") %}
+        {% set og_image = get_url(path=image_clean_path) %}
+      {% endif %}
+    {% endif %}
+
+    <meta property="og:type" content="{{ og_type }}">
+    <meta property="og:title" content="{{ og_title | striptags | trim }}">
+    {% if og_description %}
+    <meta property="og:description" content="{{ og_description | striptags | trim }}">
+    {% endif %}
+    <meta property="og:url" content="{{ og_url }}">
+    <meta property="og:site_name" content="{{ site_name | striptags | trim }}">
+    {% if og_locale %}
+    <meta property="og:locale" content="{{ og_locale }}">
+    {% endif %}
+    {% if og_image %}
+    <meta property="og:image" content="{{ og_image }}">
+      {% if image_alt %}
+    <meta property="og:image:alt" content="{{ image_alt | striptags | trim }}">
+      {% endif %}
+    {% endif %}
+    {% if page is defined %}
+      {% if page.date %}
+    <meta property="article:published_time" content="{{ page.date | date(format="%Y-%m-%dT%H:%M:%S%:z", timezone="UTC") }}">
+      {% endif %}
+      {% if page.updated %}
+    <meta property="article:modified_time" content="{{ page.updated | date(format="%Y-%m-%dT%H:%M:%S%:z", timezone="UTC") }}">
+      {% endif %}
+    {% endif %}
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
## Summary
- add a reusable partial that renders OpenGraph metadata when enabled
- include the partial from the base head template and provide configuration knobs
- document the feature and expose example settings in the sample config

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690814c0f194832f96634ad2d85d55ea

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable OpenGraph meta tag partial, includes it in the head, and documents usage with example config and per-page/section overrides.
> 
> - **Templates**:
>   - **OpenGraph partial**: New `templates/_opengraph.html` renders `og:*` tags with site-wide defaults, per-page/section overrides, fallbacks (summary/description), image URL handling (relative/absolute), locale, and article publish/modify times.
>   - **Integration**: Include the partial from `templates/_head_extend.html`.
> - **Configuration**:
>   - Add `[extra.opengraph]` options in `config.example.toml` (`enable`, `site_name`, `default_type`, optional `title`, `description`, `default_image`, `default_image_alt`, `locale`).
> - **Docs**:
>   - `USAGE.md` adds an OpenGraph section with enablement steps and front matter overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 542a68d5efcd46f6cd3f51ebd05d432239c1b6a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->