### PR TITLE
Add optional reading stats to post pages

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -251,6 +251,10 @@ Set `outdate_alert` and `outdate_alert_days` to enable the alert.
 
 In `myblog/content/posts/_index.md`, options `outdate_alert_text_before` and `outdate_alert_text_after` are the text content of the alert.
 
+## Reading Time & Word Count
+
+Set `show_post_stats = true` in the `[extra]` section of `config.toml` to display the estimated reading time and total word count next to the publish date on post pages.
+
 ## Comment
 
 You can use [giscus](https://giscus.app) as the comment system.

--- a/config.example.toml
+++ b/config.example.toml
@@ -60,3 +60,4 @@ not_found_recover_text = "« back to home »"
 reaction = false # Whether to enable anonymous emoji reactions (Note: You need to set up a working api endpoint to enable this feature)
 reaction_align = "right" # "left" | "center" | "right"
 reaction_endpoint = "https://example.com/api/reaction"
+show_post_stats = false # Whether to show reading time and word count on post pages

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1376,6 +1376,11 @@ body.post {
       }
     }
 
+    #stats {
+      margin-bottom: 1em;
+      color: var(--text-pale-color);
+    }
+
     #tags {
       margin-bottom: 1em;
       display: flex;

--- a/templates/post.html
+++ b/templates/post.html
@@ -99,6 +99,12 @@
             {% endif -%}
           </div>
 
+          {% if config.extra.show_post_stats is defined and config.extra.show_post_stats %}
+          <div id="stats">
+            <span>{{ page.reading_time }} min read &bull; {{ page.word_count }} words</span>
+          </div>
+          {% endif %}
+
           {% if page.taxonomies.tags is defined %}
           <div id="tags">
             {% for tag in page.taxonomies.tags -%}


### PR DESCRIPTION
## Summary
- add a `show_post_stats` configuration flag to control whether reading stats are shown
- render reading time and word count on post pages when the option is enabled
- document the new option and style the stats to match existing post metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908147bc7d4832fb663782efd12294d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a config-controlled display of reading time and word count on post pages.
> 
> - **Feature: Optional post reading stats**
>   - **Template (`templates/post.html`)**: Conditionally renders `page.reading_time` and `page.word_count` when `config.extra.show_post_stats` is true.
>   - **Config (`config.example.toml`)**: Adds `show_post_stats = false` flag under `[extra]`.
>   - **Styles (`sass/main.scss`)**: Adds `#stats` styling to match existing post metadata.
>   - **Docs (`USAGE.md`)**: Documents the new option and its behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da455ac8bc9d955ba62b30f7433b76c5431bd6c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->